### PR TITLE
CVE-2018-1000620

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3241,20 +3241,25 @@
       "integrity": "sha512-8wqWtdI+7IQVYCDS40H/H267zb2Lwn08Q7HT0hIqHNMkRPQdV355dPRu/hV02k2sBtZJ+KEnRVtaZWzT3hPVmQ=="
     },
     "cryptiles": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
-      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
+      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "7.x.x"
       },
       "dependencies": {
         "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+          "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "6.x.x"
           }
+        },
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
         }
       }
     },
@@ -5957,6 +5962,26 @@
         "cryptiles": "3.x.x",
         "hoek": "4.x.x",
         "sntp": "2.x.x"
+      },
+      "dependencies": {
+        "cryptiles": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+          "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
+          "requires": {
+            "boom": "5.x.x"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            }
+          }
+        }
       }
     },
     "he": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/uuid": "^3.4.4",
     "bootstrap": "^4.1.3",
     "core-js": "^2.5.4",
+    "cryptiles": "^4.1.3",
     "firebase": "^5.5.1",
     "jquery": "^3.3.1",
     "ng-animate": "^0.3.4",


### PR DESCRIPTION
**CVE-2018-1000620** (_high severity_)
Vulnerable versions: < 4.1.2
Patched version: **^4.1.3**

Details
_The NPM package cryptiles version 4.1.1 and earlier contains a CWE-331: Insufficient Entropy vulnerability in randomDigits() method that can result in An attacker is more likely to be able to brute force something that was supposed to be random.. This attack appear to be exploitable via Depends upon the calling application.. This vulnerability appears to have been fixed in 4.1.2._