### PR TITLE
Enable anonymous enhancement for chat

### DIFF
--- a/src/app/help/chat/chat.component.html
+++ b/src/app/help/chat/chat.component.html
@@ -11,8 +11,7 @@
           <hr>
           <small>
             - 
-            <em *ngIf="authService.isAnon(message.data.authorId)">anonymous</em>
-            <em *ngIf="!authService.isAnon(message.data.authorId)">{{message.data.author}}</em>
+            <em>{{message.data.author}}</em>
             , {{message.data.timestamp | timeAgo}}
           </small>
         </li>

--- a/src/app/help/chat/chat.component.ts
+++ b/src/app/help/chat/chat.component.ts
@@ -73,7 +73,7 @@ export class ChatComponent implements OnInit {
     }
   }
 
-  getMessage(messageId) {
+  getMessage(messageId: string) {
     this.message = this.chatService.getMessage(messageId);
 
     if (this.message === null) {

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,4 +1,4 @@
-export interface User {
+export interface IUser {
     uid: string;
     email: {
         address: string;

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -8,6 +8,7 @@ import { AlertService } from './alert.service';
 import { IChatWindow } from '../interfaces/chat-window';
 import { IChatMessage } from '../interfaces/chat-message';
 import { IChatChannel } from '../interfaces/chat-channel';
+import { IUserProfile } from '../interfaces/user-profile';
 
 
 
@@ -111,7 +112,7 @@ export class ChatService {
     this.db.collection('messages').doc('msg-' + v1()).set({
       'timestamp': + new Date(), // https://stackoverflow.com/questions/221294/how-do-you-get-a-timestamp-in-javascript
       'text': text,
-      'author': this.authService.getName(),
+      'author': this.authService.getDisplayName(),
       'authorId': this.authService.getUid()
     })
     .catch((err) => {


### PR DESCRIPTION
One step of #21 adding privacy settings. This enables the user to decide to post anonymous in the chat (essentially, the `authorId` is still saved for each message, but the name of the author is `anonymous` when enabling anonymous mode. This cannot be reverted, posted messages remain anonymous.